### PR TITLE
add note that Kha needs HiPE to build

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,6 +1,8 @@
 kha installation
 ================
 
+Note, you need an Erlang installation with HiPE support enabled.
+
 Minimal installation:
 
 * cp support/kha.config.example support/kha.config


### PR DESCRIPTION
It seems Kha requires HiPE to build(more specifically, the yamerl dependency needs it).
